### PR TITLE
refactor(services): replace direct error comparisons with errors.Is

### DIFF
--- a/cmd/supervisor/internal/initialize/initialize.go
+++ b/cmd/supervisor/internal/initialize/initialize.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -869,7 +870,7 @@ func (i *Initializer) createLocalNode(ctx context.Context, creds *DatabaseCreden
 		nodeInfo.NodeName = existingNodeName
 		i.logger.Infof("Local node already exists: '%s' with ID '%s'", existingNodeName, existingNodeID)
 		return nil
-	} else if err != pgx.ErrNoRows {
+	} else if !errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("failed to check for existing local node: %w", err)
 	}
 

--- a/cmd/supervisor/internal/manager/service_manager.go
+++ b/cmd/supervisor/internal/manager/service_manager.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -204,7 +205,7 @@ func (m *ServiceManager) StopService(ctx context.Context, serviceID string, forc
 
 		if _, err := svc.Controller.Stop(stopCtx, req); err != nil {
 			// During shutdown, various connection errors are expected if services are already stopping
-			if stopCtx.Err() == context.DeadlineExceeded {
+			if errors.Is(stopCtx.Err(), context.DeadlineExceeded) {
 				m.logger.Infof("Stop command to %s timed out (service may already be shutting down)", svc.Name)
 			} else if strings.Contains(err.Error(), "connection is closing") ||
 				strings.Contains(err.Error(), "Canceled") {

--- a/services/anchor/internal/database/mariadb/replication.go
+++ b/services/anchor/internal/database/mariadb/replication.go
@@ -2,6 +2,7 @@ package mariadb
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -119,7 +120,7 @@ func getReplicationChanges(db *sql.DB, tableName string, since time.Time) ([]Mar
 		LIMIT 1`
 
 	err := db.QueryRow(query, tableName).Scan(&timestampColumn)
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("error checking for timestamp column: %w", err)
 	}
 

--- a/services/anchor/internal/database/mariadb/schema.go
+++ b/services/anchor/internal/database/mariadb/schema.go
@@ -2,6 +2,7 @@ package mariadb
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -344,7 +345,7 @@ func getConstraints(db *sql.DB, schema, table string) ([]common.Constraint, erro
 
 			var deleteRule, updateRule string
 			err := db.QueryRow(actionsQuery, schema, c.Name).Scan(&deleteRule, &updateRule)
-			if err != nil && err != sql.ErrNoRows {
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				return nil, err
 			}
 

--- a/services/anchor/internal/database/mysql/replication.go
+++ b/services/anchor/internal/database/mysql/replication.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -116,7 +117,7 @@ func getReplicationChanges(db *sql.DB, tableName string, since time.Time) ([]MyS
 		LIMIT 1`
 
 	err := db.QueryRow(query, tableName).Scan(&timestampColumn)
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("error checking for timestamp column: %w", err)
 	}
 

--- a/services/anchor/internal/database/mysql/schema.go
+++ b/services/anchor/internal/database/mysql/schema.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -344,7 +345,7 @@ func getConstraints(db *sql.DB, schema, table string) ([]common.Constraint, erro
 
 			var deleteRule, updateRule string
 			err := db.QueryRow(actionsQuery, schema, c.Name).Scan(&deleteRule, &updateRule)
-			if err != nil && err != sql.ErrNoRows {
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				return nil, err
 			}
 

--- a/services/anchor/internal/database/oracle/schema.go
+++ b/services/anchor/internal/database/oracle/schema.go
@@ -3,6 +3,7 @@ package oracle
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -602,7 +603,7 @@ func discoverTablesAndColumns(db *sql.DB) (map[string]*common.TableInfo, []strin
 			}
 
 			tableInfo.Partitions = partitions
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return nil, nil, fmt.Errorf("error checking if table %s is partitioned: %v", tableName, err)
 		}
 	}

--- a/services/anchor/internal/engine/engine.go
+++ b/services/anchor/internal/engine/engine.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -208,7 +209,7 @@ func (e *Engine) getNodeIDFromDatabase(ctx context.Context) (string, error) {
 	row := e.database.Pool().QueryRow(ctx, query)
 	err := row.Scan(&nodeID)
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			// No node ID exists yet - this might be the first startup
 			if e.logger != nil {
 				e.logger.Warn("No node ID found in localidentity table - service may need initialization")

--- a/services/anchor/internal/watcher/config_watcher.go
+++ b/services/anchor/internal/watcher/config_watcher.go
@@ -2,6 +2,7 @@ package watcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -46,7 +47,7 @@ func (w *ConfigWatcher) Start(ctx context.Context) {
 
 			if err := w.checkConnectionHealth(ctx); err != nil {
 				// Don't log context cancellation errors as they're expected during shutdown
-				if ctx.Err() == nil && err != context.Canceled && err != context.DeadlineExceeded {
+				if ctx.Err() == nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 					w.logger.Error("Failed to check connection health: %v", err)
 				}
 			}

--- a/services/anchor/internal/watcher/replication_watcher.go
+++ b/services/anchor/internal/watcher/replication_watcher.go
@@ -2,6 +2,7 @@ package watcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -69,7 +70,7 @@ func (w *ReplicationWatcher) Start(ctx context.Context) {
 			}
 
 			if err := w.periodicReplicationHealthCheck(ctx); err != nil {
-				if ctx.Err() == nil && err != context.Canceled && err != context.DeadlineExceeded {
+				if ctx.Err() == nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 					w.logger.Error("Failed periodic replication health check: %v", err)
 				}
 			}

--- a/services/anchor/internal/watcher/schema_watcher.go
+++ b/services/anchor/internal/watcher/schema_watcher.go
@@ -2,6 +2,7 @@ package watcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -295,7 +296,7 @@ func (w *SchemaWatcher) Start(ctx context.Context) {
 
 			if err != nil {
 				// Don't log context cancellation errors as they're expected during shutdown
-				if ctx.Err() == nil && err != context.Canceled && err != context.DeadlineExceeded {
+				if ctx.Err() == nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 					if w.logger != nil {
 						w.logger.Errorf("Failed to check schema changes: %v", err)
 					}

--- a/services/clientapi/internal/engine/engine.go
+++ b/services/clientapi/internal/engine/engine.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -187,7 +188,7 @@ func (e *Engine) Start(ctx context.Context) error {
 
 	// Start HTTP server
 	go func() {
-		if err := e.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := e.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			if e.logger != nil {
 				e.logger.Errorf("HTTP server error: %v", err)
 			}

--- a/services/mesh/internal/storage/postgres.go
+++ b/services/mesh/internal/storage/postgres.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -112,7 +113,7 @@ func (s *PostgresStorage) GetMessage(ctx context.Context, id string) (*Message, 
 	`, id).Scan(&msg.ID, &msg.From, &msg.To, &msg.Content, &msg.Timestamp)
 
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, fmt.Errorf("message not found: %s", id)
 		}
 		s.logger.Errorf("Failed to get message (ID: %s): %v", id, err)
@@ -174,7 +175,7 @@ func (s *PostgresStorage) GetState(ctx context.Context, key string) ([]byte, err
 	`, key).Scan(&value)
 
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, fmt.Errorf("state not found: %s", key)
 		}
 		s.logger.Errorf("Failed to get state (key: %s): %v", key, err)
@@ -241,7 +242,7 @@ func (s *PostgresStorage) GetNodeState(ctx context.Context, nodeID string) (inte
 	`, nodeID).Scan(&stateBytes)
 
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, fmt.Errorf("node state not found: %s", nodeID)
 		}
 		s.logger.Errorf("Failed to get node state (node ID: %s): %v", nodeID, err)
@@ -302,7 +303,7 @@ func (s *PostgresStorage) GetLog(ctx context.Context, index uint64) (interface{}
 	`, index).Scan(&entryBytes)
 
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, fmt.Errorf("log entry not found: %d", index)
 		}
 		s.logger.Errorf("Failed to get log (index: %d): %v", index, err)
@@ -403,7 +404,7 @@ func (s *PostgresStorage) GetRoute(ctx context.Context, destination string) (int
 	`, destination).Scan(&routeBytes)
 
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, fmt.Errorf("route not found: %s", destination)
 		}
 		s.logger.Errorf("Failed to get route (destination: %s): %v", destination, err)
@@ -505,7 +506,7 @@ func (s *PostgresStorage) GetConfig(ctx context.Context, key string) (interface{
 	`, key).Scan(&valueBytes)
 
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, fmt.Errorf("config not found: %s", key)
 		}
 		s.logger.Errorf("Failed to get config (key: %s): %v", key, err)
@@ -586,7 +587,7 @@ func (s *PostgresStorage) GetLocalIdentity(ctx context.Context) (*LocalIdentity,
 	`).Scan(&identity.IdentityID)
 
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil // No local identity found - this is a valid state
 		}
 		s.logger.Errorf("Failed to get local identity: %v", err)
@@ -607,7 +608,7 @@ func (s *PostgresStorage) GetMeshInfo(ctx context.Context) (*MeshInfo, error) {
 		&mesh.Created, &mesh.Updated)
 
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil // No mesh found - this is a valid state
 		}
 		s.logger.Errorf("Failed to get mesh info: %v", err)
@@ -632,7 +633,7 @@ func (s *PostgresStorage) GetNodeInfo(ctx context.Context, nodeID string) (*Node
 		&node.IPAddress, &node.Port, &node.Status, &node.Created, &node.Updated)
 
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil // Node not found
 		}
 		s.logger.Errorf("Failed to get node info (node ID: %s): %v", nodeID, err)
@@ -717,7 +718,7 @@ func (tx *PostgresTransaction) GetMessage(ctx context.Context, id string) (*Mess
 	`, id).Scan(&msg.ID, &msg.From, &msg.To, &msg.Content, &msg.Timestamp)
 
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, fmt.Errorf("message not found: %s", id)
 		}
 		tx.logger.Errorf("Failed to get message in transaction (ID: %s): %v", id, err)
@@ -759,7 +760,7 @@ func (tx *PostgresTransaction) GetState(ctx context.Context, key string) ([]byte
 	`, key).Scan(&value)
 
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, fmt.Errorf("state not found: %s", key)
 		}
 		tx.logger.Errorf("Failed to get state in transaction (key: %s): %v", key, err)

--- a/services/queryapi/internal/engine/engine.go
+++ b/services/queryapi/internal/engine/engine.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -81,7 +82,7 @@ func (e *Engine) Start(ctx context.Context) error {
 
 	// Start HTTP server
 	go func() {
-		if err := e.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := e.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			atomic.AddInt64(&e.metrics.errors, 1)
 		}
 	}()

--- a/services/serviceapi/internal/engine/engine.go
+++ b/services/serviceapi/internal/engine/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -148,7 +149,7 @@ func (e *Engine) Start(ctx context.Context) error {
 
 	// Start HTTP server
 	go func() {
-		if err := e.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := e.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			if e.logger != nil {
 				e.logger.Errorf("HTTP server error: %v", err)
 			}

--- a/services/unifiedmodel/internal/adapters/mysqladapter.go
+++ b/services/unifiedmodel/internal/adapters/mysqladapter.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -629,7 +630,7 @@ func (a *MySQLAdapter) discoverPartitionInfo(table *models.MySQLTable) error {
 		&partitionInfo.SubPartitionBy,
 		&partitionInfo.SubPartitions,
 	)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil // Table is not partitioned
 	}
 	if err != nil {


### PR DESCRIPTION
## Description
Replaced all instances of direct error comparison (e.g. err == X) with errors.Is(err, X) to ensure correct behavior when errors are wrapped.

## Type of Change
<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (updates to README, API docs, etc.)
- [ ] **Performance improvement** (code change that improves performance)
- [x] **Refactoring** (code change that neither fixes a bug nor adds a feature)
- [ ] **Test addition** (adding missing tests or correcting existing tests)
- [ ] **Build/CI change** (changes to build system, CI configuration, etc.)

## Service/Component Affected
<!-- Mark the service(s) or component(s) that are affected by this change -->

- [x] **Supervisor Service** (`cmd/supervisor/`)
- [ ] **Security Service** (`services/security/`)
- [ ] **License Service** (`services/license/`)
- [ ] **Core Service** (`services/core/`)
- [x] **Unified Model Service** (`services/unifiedmodel/`)
- [x] **Anchor Service** (`services/anchor/`)
- [ ] **Transformation Service** (`services/transformation/`)
- [x] **Mesh Service** (`services/mesh/`)
- [x] **Client API** (`services/clientapi/`)
- [x] **Service API** (`services/serviceapi/`)
- [x] **Query API** (`services/queryapi/`)
- [ ] **Webhook Service** (`services/webhook/`)
- [ ] **MCP Server Service** (`services/mcpserver/`)
- [ ] **CLI** (`cmd/cli/`)
- [ ] **Shared Libraries** (`pkg/`)
- [ ] **Protocol Buffers** (`api/proto/`)
- [ ] **Documentation** (README, CONTRIBUTING, etc.)
- [ ] **Build System** (Makefile, scripts, etc.)

## Database Adapter Changes
<!-- If this PR affects database adapters, specify which ones -->

- [ ] **PostgreSQL**
- [x] **MySQL**
- [ ] **MariaDB**
- [ ] **SQL Server**
- [ ] **Oracle**
- [ ] **IBM Db2**
- [ ] **MongoDB**
- [ ] **CosmosDB**
- [ ] **Redis**
- [ ] **DynamoDB**
- [ ] **Neo4j**
- [ ] **Pinecone**
- [ ] **ClickHouse**
- [ ] **Snowflake**
- [ ] **Elasticsearch**
- [ ] **Cassandra**
- [ ] **EdgeDB**
- [ ] **CockroachDB**

## Testing
- [x] Manual verification of affected services (no behavior regressions)
- [x] `go test ./...` passes

## Checklist
<!-- Mark items with an 'x' to indicate completion -->

### Code Quality
- [x] **Code follows** the project's style guidelines
- [x] **Self-review** of code completed
- [ ] **Code is commented**, particularly in hard-to-understand areas
- [x] **No new warnings** generated
- [x] **Linting passes** (`make lint`)
- [x] **Static analysis passes** (`go vet ./...`)

## Breaking Changes
(None)
