### PR TITLE
refactor(config): avoid shadowing built-in copy identifier

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,11 +37,11 @@ func (c *Config) GetAll() map[string]string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	copy := make(map[string]string)
+	copied := make(map[string]string, len(c.values))
 	for k, v := range c.values {
-		copy[k] = v
+		copied[k] = v
 	}
-	return copy
+	return copied
 }
 
 // Update updates configuration values


### PR DESCRIPTION
## Description
Renamed the local variable `copy` to `copied` in `Config.GetAll` (pkg/config/config.go)  
to avoid shadowing the built-in Go function `copy`.

Also added preallocation with `len(c.values)` to reduce map growth during iteration.

## Type of Change
- [x] **Refactoring** (code change that neither fixes a bug nor adds a feature)

## Service/Component Affected
- [x] **Shared Libraries** (`pkg/`)

## Checklist
<!-- Mark items with an 'x' to indicate completion -->

### Code Quality
- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] No new warnings generated
- [x] Linting passes
- [x] Static analysis passes (`go vet ./...`)