### PR TITLE
chore(lint): add golangci-lint v2 config for stricter linting

### DIFF
--- a/.golangci-v2.yml
+++ b/.golangci-v2.yml
@@ -1,0 +1,94 @@
+version: "2"
+run:
+  go: '1.23'
+  timeout: 5m
+linters:
+  enable:
+    - bodyclose
+    - gocyclo
+    - gosec
+    - nolintlint
+    - govet
+    - errcheck
+    - errname
+    - ineffassign
+    - unused
+    - staticcheck
+    - cyclop
+    - copyloopvar
+    - asasalint
+    - bidichk
+    - exhaustive
+    - gocognit
+    - gocritic
+    - iface
+    - lll
+    - whitespace
+    - zerologlint
+    - forcetypeassert
+    - makezero
+    - dogsled
+    - tparallel
+    - testifylint
+    - decorder
+    - fatcontext
+    - gosmopolitan
+    - revive
+    - unparam
+    - misspell
+  disable:
+    - err113
+  settings:
+    dupl:
+      threshold: 100
+    gocognit:
+      min-complexity: 20
+    gocyclo:
+      min-complexity: 15
+    cyclop:
+      max-complexity: 15
+    gocritic:
+      disabled-checks:
+        - exitAfterDefer
+    dogsled:
+      max-blank-identifiers: 2
+    govet:
+      enable:
+        - shadow
+    errcheck:
+      exclude-functions:
+        - fmt.Fprintln
+        - fmt.Fprint
+        - fmt.Fprintf
+  exclusions:
+    generated: lax
+    rules:
+      - path: (.+)\.go$
+        text: error return value not checked
+      - path: _test\.go
+        linters:
+          - gosec
+          - errcheck
+          - lll
+          - gocyclo
+          - dupl
+formatters:
+  enable:
+    - gofmt
+    - goimports
+    - golines
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/redbco/redb-open
+    golines:
+      max-len: 120
+  issues:
+    max-issues-per-linter: 0
+    max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,14 @@ dev-tools:
 lint:
 	golangci-lint run ./...
 
+# Lint the code using golangci-lint v2
+.PHONY: lint-v2
+lint-v2:
+	@for d in ./cmd/* ./services/* ./pkg/* ; do \
+		echo "Linting $$d..."; \
+		golangci-lint run --config=.golangci-v2.yml $$d/... || exit 1; \
+	done
+
 # Build for multiple platforms
 .PHONY: build-all
 build-all: $(BUILD_DIR)


### PR DESCRIPTION
## Description
This PR introduces a new `.golangci-v2.yml` config file with stricter and more comprehensive linting rules, including checks for cognitive complexity, security, formatting, and common Go pitfalls.

The goal is to gradually bring the codebase into compliance without breaking the current CI or development workflow.
Once violations are resolved, the project can fully migrate to this configuration.

## Why
- Improves code quality and consistency
- Encourages simpler, more maintainable logic
- Catches potential bugs and unsafe patterns earlier
- Aligns the codebase with modern Go best practices

## Summary of Findings (from `make lint-v2`)

```yaml
97 issues:
* errcheck:     9
* gocognit:    14
* gocyclo:      5
* goimports:    1
* golines:      2
* gosec:        2
* govet:        4
* lll:          9
* revive:      50
* unparam:      1
```

## Usage

```bash
make lint-v2
```