### PR TITLE
refactor(cli): fix lll issues and refactor header rendering for environments

### DIFF
--- a/cmd/cli/cmd/branches.go
+++ b/cmd/cli/cmd/branches.go
@@ -9,7 +9,8 @@ import (
 var branchesCmd = &cobra.Command{
 	Use:   "branches",
 	Short: "Manage branches",
-	Long:  `Commands for managing branches including showing details, modifying, attaching, detaching, and deleting branches.`,
+	Long: "Commands for managing branches including showing details, modifying, attaching, detaching, " +
+		"and deleting branches.",
 }
 
 // showBranchCmd represents the show command

--- a/cmd/cli/cmd/databases.go
+++ b/cmd/cli/cmd/databases.go
@@ -9,7 +9,8 @@ import (
 var databasesCmd = &cobra.Command{
 	Use:   "databases",
 	Short: "Manage databases",
-	Long:  `Commands for managing databases including listing, showing details, creating, modifying, connecting, reconnecting, disconnecting, wiping, dropping, and cloning table data.`,
+	Long: "Commands for managing databases including listing, showing details, creating, modifying, connecting, " +
+		"reconnecting, disconnecting, wiping, dropping, and cloning table data.",
 }
 
 // listDatabasesCmd represents the list command

--- a/cmd/cli/cmd/environments.go
+++ b/cmd/cli/cmd/environments.go
@@ -9,7 +9,8 @@ import (
 var environmentsCmd = &cobra.Command{
 	Use:   "environments",
 	Short: "Manage environments",
-	Long:  `Commands for managing environments including listing, showing details, adding, modifying, and deleting environments.`,
+	Long: "Commands for managing environments including listing, showing details, adding, modifying, " +
+		"and deleting environments.",
 }
 
 // listEnvironmentsCmd represents the list command

--- a/cmd/cli/cmd/instances.go
+++ b/cmd/cli/cmd/instances.go
@@ -9,7 +9,8 @@ import (
 var instancesCmd = &cobra.Command{
 	Use:   "instances",
 	Short: "Manage instances",
-	Long:  `Commands for managing instances including listing, showing details, connecting, modifying, reconnecting, and disconnecting instances.`,
+	Long: "Commands for managing instances including listing, showing details, connecting, modifying, reconnecting, " +
+		"and disconnecting instances.",
 }
 
 // listInstancesCmd represents the list command

--- a/cmd/cli/cmd/main.go
+++ b/cmd/cli/cmd/main.go
@@ -30,7 +30,8 @@ func printVersionInfo() {
 var rootCmd = &cobra.Command{
 	Use:   "redb-cli",
 	Short: "reDB Command Line Interface",
-	Long:  `A comprehensive CLI for managing reDB resources including authentication, regions, workspaces, databases, and more.`,
+	Long: "A comprehensive CLI for managing reDB resources including authentication, regions, workspaces, databases, " +
+		"and more.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Check if --version flag is set
 		if cmd.Flags().Lookup("version") != nil && cmd.Flags().Lookup("version").Changed {

--- a/cmd/cli/cmd/repos.go
+++ b/cmd/cli/cmd/repos.go
@@ -9,7 +9,8 @@ import (
 var reposCmd = &cobra.Command{
 	Use:   "repos",
 	Short: "Manage repositories",
-	Long:  `Commands for managing repositories including listing, showing details, adding, modifying, cloning, and deleting repositories.`,
+	Long: "Commands for managing repositories including listing, showing details, adding, modifying, cloning, " +
+		"and deleting repositories.",
 }
 
 // listReposCmd represents the list command

--- a/cmd/cli/cmd/setup.go
+++ b/cmd/cli/cmd/setup.go
@@ -27,7 +27,8 @@ func (e SetupError) Error() string {
 var setupCmd = &cobra.Command{
 	Use:   "setup",
 	Short: "Create initial tenant, user, and workspace",
-	Long:  `Create the first tenant, user, and workspace for a new reDB installation. This command is only available when no tenants exist in the system.`,
+	Long: "Create the first tenant, user, and workspace for a new reDB installation. " +
+		"This command is only available when no tenants exist in the system.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := performInitialSetup()
 		// Check if it's a SetupError and suppress usage help

--- a/cmd/cli/cmd/workspaces.go
+++ b/cmd/cli/cmd/workspaces.go
@@ -9,7 +9,8 @@ import (
 var workspacesCmd = &cobra.Command{
 	Use:   "workspaces",
 	Short: "Manage workspaces",
-	Long:  `Commands for managing workspaces including listing, showing details, adding, modifying, and deleting workspaces.`,
+	Long: "Commands for managing workspaces including listing, showing details, adding, modifying, " +
+		"and deleting workspaces.",
 }
 
 // listWorkspacesCmd represents the list command

--- a/cmd/cli/internal/environments/environments.go
+++ b/cmd/cli/internal/environments/environments.go
@@ -117,9 +117,19 @@ func ListEnvironments() error {
 
 	fmt.Println()
 
+	headers := []string{
+		"Name", "Description", "Production", "Criticality", "Priority",
+		"Status", "Instances", "Databases", "Repositories", "Mappings", "Relationships",
+	}
+
+	underlines := make([]string, len(headers))
+	for i := range headers {
+		underlines[i] = strings.Repeat("-", len(headers[i]))
+	}
+
 	// Print header
-	fmt.Fprintln(w, "Name\tDescription\tProduction\tCriticality\tPriority\tStatus\tInstances\tDatabases\tRepositories\tMappings\tRelationships")
-	fmt.Fprintln(w, "----\t-----------\t----------\t-----------\t--------\t------\t---------\t---------\t------------\t--------\t-------------")
+	fmt.Fprintln(w, strings.Join(headers, "\t"))
+	fmt.Fprintln(w, strings.Join(underlines, "\t"))
 
 	// Print each environment
 	for _, environment := range environments {


### PR DESCRIPTION
## Description
This PR resolves all lll linter warnings across CLI code and improves the maintainability of tabular output in the environments command.
Specifically, header strings are no longer hardcoded across multiple lines — they are now generated from a slice, and the underline row is calculated dynamically.

## Type of Change
<!-- Mark the appropriate option(s) with an 'x' -->

- [x] **Code style** change (formatting, etc.)

## Service/Component Affected
<!-- Mark the service(s) or component(s) that are affected by this change -->

- [x] **CLI** (`cmd/cli/`)

This PR continues the gradual adoption of stricter linters introduced in #5 by addressing all `lll` warnings.