### PR TITLE
refactor(cli): fix errcheck issues

### DIFF
--- a/cmd/cli/cmd/commands.go
+++ b/cmd/cli/cmd/commands.go
@@ -103,13 +103,13 @@ PowerShell:
 	Run: func(cmd *cobra.Command, args []string) {
 		switch args[0] {
 		case "bash":
-			cmd.Root().GenBashCompletion(os.Stdout)
+			_ = cmd.Root().GenBashCompletion(os.Stdout)
 		case "zsh":
-			cmd.Root().GenZshCompletion(os.Stdout)
+			_ = cmd.Root().GenZshCompletion(os.Stdout)
 		case "fish":
-			cmd.Root().GenFishCompletion(os.Stdout, true)
+			_ = cmd.Root().GenFishCompletion(os.Stdout, true)
 		case "powershell":
-			cmd.Root().GenPowerShellCompletion(os.Stdout)
+			_ = cmd.Root().GenPowerShellCompletion(os.Stdout)
 		}
 	},
 }

--- a/cmd/cli/internal/auth/auth.go
+++ b/cmd/cli/internal/auth/auth.go
@@ -384,7 +384,7 @@ func Profile() error {
 	fmt.Fprintf(w, "Email\t%s\n", response.Profile.Email)
 	fmt.Fprintf(w, "Name\t%s\n", response.Profile.Name)
 
-	w.Flush()
+	_ = w.Flush()
 	fmt.Println()
 	return nil
 }
@@ -432,7 +432,7 @@ func ListSessions() error {
 		)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 	fmt.Println()
 	return nil
 }
@@ -715,7 +715,7 @@ func Status() error {
 	fmt.Fprintf(w, "Access Token Expires:\t%s\n", accessExpiry)
 	fmt.Fprintf(w, "Refresh Token:\t%s\n", refreshStatus)
 	fmt.Fprintf(w, "Refresh Token Expires:\t%s\n", refreshExpiry)
-	w.Flush()
+	_ = w.Flush()
 
 	// Show warnings if tokens are expired
 	if accessExpired {

--- a/cmd/cli/internal/branches/branches.go
+++ b/cmd/cli/internal/branches/branches.go
@@ -130,7 +130,7 @@ func ShowBranch(repoBranchStr string) error {
 				head,
 				commit.CommitDate)
 		}
-		w.Flush()
+		_ = w.Flush()
 	}
 
 	if len(branch.Branches) > 0 {
@@ -149,7 +149,7 @@ func ShowBranch(repoBranchStr string) error {
 				childBranch.DatabaseID,
 				childBranch.Status)
 		}
-		w.Flush()
+		_ = w.Flush()
 	}
 
 	fmt.Println()

--- a/cmd/cli/internal/databases/databases.go
+++ b/cmd/cli/internal/databases/databases.go
@@ -205,7 +205,7 @@ func formatSchemaData(schemaJSON string) error {
 				col.ColumnDefault,
 				unique)
 		}
-		w.Flush()
+		_ = w.Flush()
 		fmt.Println()
 	}
 
@@ -290,7 +290,7 @@ func formatTablesData(tablesJSON string) error {
 				privileged,
 				confidence)
 		}
-		w.Flush()
+		_ = w.Flush()
 
 		// Show classification scores if available
 		if len(table.ClassificationScores) > 0 {
@@ -301,7 +301,7 @@ func formatTablesData(tablesJSON string) error {
 			for _, score := range table.ClassificationScores {
 				fmt.Fprintf(scoreW, "%s\t%.2f\t%s\n", score.Category, score.Score, score.Reason)
 			}
-			scoreW.Flush()
+			_ = scoreW.Flush()
 		}
 		fmt.Println()
 	}
@@ -360,7 +360,7 @@ func ListDatabases() error {
 			db.Status,
 			enabled)
 	}
-	w.Flush()
+	_ = w.Flush()
 	fmt.Println()
 	return nil
 }

--- a/cmd/cli/internal/environments/environments.go
+++ b/cmd/cli/internal/environments/environments.go
@@ -147,7 +147,7 @@ func ListEnvironments() error {
 			environment.RelationshipCount)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 	fmt.Println()
 	return nil
 }

--- a/cmd/cli/internal/httpclient/httpclient.go
+++ b/cmd/cli/internal/httpclient/httpclient.go
@@ -91,7 +91,9 @@ func (c *HTTPClient) makeRequest(method, url string, body interface{}, requireAu
 
 // handleResponse processes the HTTP response and handles errors
 func (c *HTTPClient) handleResponse(resp *http.Response, result interface{}) error {
-	defer resp.Body.Close()
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/cmd/cli/internal/instances/instances.go
+++ b/cmd/cli/internal/instances/instances.go
@@ -182,7 +182,7 @@ func ListInstances() error {
 			enabled)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 	fmt.Println()
 	return nil
 }

--- a/cmd/cli/internal/mesh/mesh.go
+++ b/cmd/cli/internal/mesh/mesh.go
@@ -286,7 +286,7 @@ func ListNodes(meshID string) error {
 		)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 
 	return nil
 }

--- a/cmd/cli/internal/regions/regions.go
+++ b/cmd/cli/internal/regions/regions.go
@@ -123,7 +123,7 @@ func ListRegions() error {
 			region.Description)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 	fmt.Println()
 	return nil
 }
@@ -161,7 +161,7 @@ func ShowRegion(regionName string) error {
 	fmt.Fprintf(w, "Node Count:\t%d\n", detailedRegion.NodeCount)
 	fmt.Fprintf(w, "Created:\t%s\n", detailedRegion.Created)
 	fmt.Fprintf(w, "Updated:\t%s\n", detailedRegion.Updated)
-	w.Flush()
+	_ = w.Flush()
 	fmt.Println()
 
 	return nil

--- a/cmd/cli/internal/repos/repos.go
+++ b/cmd/cli/internal/repos/repos.go
@@ -122,7 +122,7 @@ func ListRepos() error {
 			repo.RepoDescription,
 			repo.OwnerID)
 	}
-	w.Flush()
+	_ = w.Flush()
 	fmt.Println()
 	return nil
 }
@@ -188,7 +188,7 @@ func ShowRepo(repoName string) error {
 				branch.DatabaseID,
 				branch.Status)
 		}
-		w.Flush()
+		_ = w.Flush()
 	}
 
 	fmt.Println()

--- a/cmd/cli/internal/tenants/tenants.go
+++ b/cmd/cli/internal/tenants/tenants.go
@@ -105,7 +105,7 @@ func ListTenants() error {
 			tenant.URL)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 	fmt.Println()
 	return nil
 }

--- a/cmd/cli/internal/users/users.go
+++ b/cmd/cli/internal/users/users.go
@@ -112,7 +112,7 @@ func ListUsers() error {
 			user.UserID)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 	fmt.Println()
 	return nil
 }

--- a/cmd/cli/internal/workspaces/workspaces.go
+++ b/cmd/cli/internal/workspaces/workspaces.go
@@ -110,7 +110,7 @@ func ListWorkspaces() error {
 			workspace.RelationshipCount)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 	fmt.Println()
 	return nil
 }


### PR DESCRIPTION
## Type of Change
<!-- Mark the appropriate option(s) with an 'x' -->

- [x] **Code style** change (formatting, etc.)

## Service/Component Affected
<!-- Mark the service(s) or component(s) that are affected by this change -->

- [x] **CLI** (`cmd/cli/`)

This PR continues the gradual adoption of stricter linters introduced in #5 by addressing all `errcheck` warnings.