### PR TITLE
fix: suppress gosec warnings

### DIFF
--- a/cmd/cli/internal/config/config.go
+++ b/cmd/cli/internal/config/config.go
@@ -56,12 +56,13 @@ func Init(configFile string) error {
 
 	// Create config directory if it doesn't exist
 	configDir := filepath.Dir(configFile)
-	if err := os.MkdirAll(configDir, 0o755); err != nil {
+	if err := os.MkdirAll(configDir, 0o750); err != nil {
 		return fmt.Errorf("failed to create config directory: %v", err)
 	}
 
 	// Try to read existing config file
 	if _, err := os.Stat(configFile); err == nil {
+		//nolint:gosec // configFile is constructed internally and safe to read
 		data, err := os.ReadFile(configFile)
 		if err != nil {
 			return fmt.Errorf("failed to read config file: %v", err)


### PR DESCRIPTION
## Type of Change
<!-- Mark the appropriate option(s) with an 'x' -->

- [x] **Code style** change (formatting, etc.)

## Service/Component Affected
<!-- Mark the service(s) or component(s) that are affected by this change -->

- [x] **CLI** (`cmd/cli/`)

This PR continues the gradual adoption of stricter linters introduced in #5 by addressing all `gosec` warnings.